### PR TITLE
Make WatermarkType a little more usable.

### DIFF
--- a/goarion.go
+++ b/goarion.go
@@ -8,118 +8,113 @@ package goarion
 //
 import "C"
 import (
-  "errors"
-  "unsafe"
+	"errors"
+	"unsafe"
 )
 
 var (
-  errNoOutpuData         = errors.New("Image data length is zero")
-  errInvalidSourceFormat = errors.New("Invalid data source format")
-  errOperation           = errors.New("Error running the operation")
-  errEmptyInputUrl       = errors.New("Empty intput url")
-  errInvalidHeight       = errors.New("Provided height is invalid")
-  errInvalidWidth        = errors.New("Provided width is invalid")
-  errInvalidQuality      = errors.New("Provided quality is invalid")
+	errNoOutpuData         = errors.New("Image data length is zero")
+	errInvalidSourceFormat = errors.New("Invalid data source format")
+	errOperation           = errors.New("Error running the operation")
+	errInvalidHeight       = errors.New("Provided height is invalid")
+	errInvalidWidth        = errors.New("Provided width is invalid")
+	errInvalidQuality      = errors.New("Provided quality is invalid")
 )
 
-// Performs a resize operation given an input url
+// ResizeFromFile Performs a resize operation given an input url
 // On success this will return JPEG data in a byte array
-func ResizeFromFile(inputUrl string, options Options) ([]byte, string, error) {
-  
-//   if inputUrl == nil {    
-//     return nil, errEmptyInputUrl
-//   }
-  
-  // Set a default JSON response...
-  json := "{\"result\":false,\"error_message\":\"Unknown error\"}"
-  
-  if options.Height <= 0 {
-    return nil, json, errInvalidHeight
-  }
-  
-  if options.Width <= 0 {
-    return nil, json, errInvalidWidth
-  }
-  
-  if options.Quality <= 0 {
-    return nil, json, errInvalidQuality
-  }
-  
-  cinputUrl       := C.CString(inputUrl)
-  inputOptions    := C.struct_ArionInputOptions{correctOrientation: 1, inputUrl:cinputUrl}
-  algo            := C.CString(AlgoToString(options.Algo))
-  gravity         := C.CString(GravtiyToString(options.Gravity))
-  watermarkUrl    := C.CString(options.WatermarkUrl)
-  watermarkType   := C.CString(WatermarkTypeToString(options.WatermarkType))
-  
-  // Ability to save to file (to disk) from Arion
-  // coutputUrl := C.CString(outputUrl)
-  // If used, put this after call to resize!
-  // defer C.free(unsafe.Pointer(coutputUrl))
-  
-  resizeOptions := C.struct_ArionResizeOptions{algo:            algo, 
-                                               height:          C.uint(options.Height), 
-                                               width:           C.uint(options.Width),
-                                               gravity:         gravity,
-                                               quality:         C.uint(options.Quality),
-                                               sharpenRadius:   C.float(options.SharpenRadius),
-                                               sharpenAmount:   C.uint(options.SharpenAmount),
-                                               preserveMeta:    C.uint(0),
-                                               watermarkUrl:    watermarkUrl,
-                                               watermarkType:   watermarkType,
-                                               watermarkMin:    C.float(options.WatermarkMin),
-                                               watermarkMax:    C.float(options.WatermarkMax),
-                                               watermarkAmount: C.float(options.WatermarkAmount)}
+func ResizeFromFile(inputURL string, options Options) ([]byte, string, error) {
 
-  // Run it!
-  result := C.ArionResize(inputOptions, resizeOptions)
-  
-  // Cleanup
-  defer C.free(unsafe.Pointer(cinputUrl))
-  defer C.free(unsafe.Pointer(algo))
-  defer C.free(unsafe.Pointer(gravity))
-  defer C.free(unsafe.Pointer(watermarkUrl))
-  defer C.free(unsafe.Pointer(watermarkType))
-  
-  // Read back results
-  outputData := unsafe.Pointer(result.outputData)
-  outputSize := int(result.outputSize)
-  outputJson := unsafe.Pointer(result.resultJson)
-  returnCode := int(result.returnCode)
-  
-  // If we got back json make sure it gets freed
-  if outputJson != nil {
-    json = C.GoString(result.resultJson)
-    defer C.free(outputJson)
-  }
+	// Set a default JSON response...
+	json := "{\"result\":false,\"error_message\":\"Unknown error\"}"
 
-  // Now check the error code
-  if returnCode != 0 {
-    
-    // If we got back output data make sure it gets freed
-    if outputData != nil {
-      defer C.free(outputData)
-    }
+	if options.Height <= 0 {
+		return nil, json, errInvalidHeight
+	}
 
-    return nil, json, errOperation
-  }
-   
-  // We should have data, but we don't
-  if outputData == nil {
-    return nil, json, errNoOutpuData
-  }
+	if options.Width <= 0 {
+		return nil, json, errInvalidWidth
+	}
 
-  // This works, but creates an extra copy...
-  // jpeg := C.GoBytes(outputData, result.outputSize)
-  // If we got back output data make sure it gets freed
-  // if outputData != nil {
-  //   defer C.free(outputData)
-  // }
-  
-  // Avoid the extra copy 
-  // See https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
-  // TODO: does this need to be freed or will Go use garbage collection?
-  jpeg := (*[1 << 30]byte)(outputData)[:outputSize:outputSize]
-  
-  return jpeg, json, nil
+	if options.Quality <= 0 {
+		return nil, json, errInvalidQuality
+	}
+
+	cinputURL := C.CString(inputURL)
+	inputOptions := C.struct_ArionInputOptions{correctOrientation: 1, inputUrl: cinputURL}
+	algo := C.CString(AlgoToString(options.Algo))
+	gravity := C.CString(GravtiyToString(options.Gravity))
+	watermarkURL := C.CString(options.WatermarkURL)
+	watermarkType := C.CString(WatermarkTypeToString(options.WatermarkType))
+
+	// Ability to save to file (to disk) from Arion
+	// coutputUrl := C.CString(outputUrl)
+	// If used, put this after call to resize!
+	// defer C.free(unsafe.Pointer(coutputUrl))
+
+	resizeOptions := C.struct_ArionResizeOptions{algo: algo,
+		height:          C.uint(options.Height),
+		width:           C.uint(options.Width),
+		gravity:         gravity,
+		quality:         C.uint(options.Quality),
+		sharpenRadius:   C.float(options.SharpenRadius),
+		sharpenAmount:   C.uint(options.SharpenAmount),
+		preserveMeta:    C.uint(0),
+		watermarkUrl:    watermarkURL,
+		watermarkType:   watermarkType,
+		watermarkMin:    C.float(options.WatermarkMin),
+		watermarkMax:    C.float(options.WatermarkMax),
+		watermarkAmount: C.float(options.WatermarkAmount)}
+
+	// Run it!
+	result := C.ArionResize(inputOptions, resizeOptions)
+
+	// Cleanup
+	defer C.free(unsafe.Pointer(cinputURL))
+	defer C.free(unsafe.Pointer(algo))
+	defer C.free(unsafe.Pointer(gravity))
+	defer C.free(unsafe.Pointer(watermarkURL))
+	defer C.free(unsafe.Pointer(watermarkType))
+
+	// Read back results
+	outputData := unsafe.Pointer(result.outputData)
+	outputSize := int(result.outputSize)
+	outputJSON := unsafe.Pointer(result.resultJson)
+	returnCode := int(result.returnCode)
+
+	// If we got back json make sure it gets freed
+	if outputJSON != nil {
+		json = C.GoString(result.resultJson)
+		defer C.free(outputJSON)
+	}
+
+	// Now check the error code
+	if returnCode != 0 {
+
+		// If we got back output data make sure it gets freed
+		if outputData != nil {
+			defer C.free(outputData)
+		}
+
+		return nil, json, errOperation
+	}
+
+	// We should have data, but we don't
+	if outputData == nil {
+		return nil, json, errNoOutpuData
+	}
+
+	// This works, but creates an extra copy...
+	// jpeg := C.GoBytes(outputData, result.outputSize)
+	// If we got back output data make sure it gets freed
+	// if outputData != nil {
+	//   defer C.free(outputData)
+	// }
+
+	// Avoid the extra copy
+	// See https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
+	// TODO: does this need to be freed or will Go use garbage collection?
+	jpeg := (*[1 << 30]byte)(outputData)[:outputSize:outputSize]
+
+	return jpeg, json, nil
 }

--- a/goarion_test.go
+++ b/goarion_test.go
@@ -1,18 +1,18 @@
 package goarion
 
 import (
-  "bytes"
-  "fmt"
-  "image"
-  _ "image/jpeg"
-  "io/ioutil"
-  "os"
-  "path"
-  "testing"
-  "strings"
-  "encoding/json"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
 
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 const tmpdir = "./testoutput"
@@ -21,123 +21,124 @@ const tmpdir = "./testoutput"
 // Setup the temp directory for a new test run
 //------------------------------------------------------------------------------
 func cleanup() {
-  os.RemoveAll(tmpdir)
-  os.MkdirAll(tmpdir, 0775)
+	os.RemoveAll(tmpdir)
+	os.MkdirAll(tmpdir, 0775)
 }
+
 //------------------------------------------------------------------------------
 // Write jpeg encoded byte array to disk
 //------------------------------------------------------------------------------
 func dumpImage(filename string, data []byte) {
-  err := ioutil.WriteFile(path.Join(tmpdir, filename+".jpg"), data, 0665)
-  if err != nil {
-    panic(err)
-  }
+	err := ioutil.WriteFile(path.Join(tmpdir, filename+".jpg"), data, 0665)
+	if err != nil {
+		panic(err)
+	}
 }
 
 //------------------------------------------------------------------------------
 // Helper for resizing image and saving it to disk
 //------------------------------------------------------------------------------
 func imageTestHelper(t *testing.T, srcPath string, outputPrefix string, opts Options) {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-  // Perform the resize operation and make sure there are no errors
-  // Data will be jpeg encoded
-  data, _, err := ResizeFromFile(srcPath, opts)
+	// Perform the resize operation and make sure there are no errors
+	// Data will be jpeg encoded
+	data, _, err := ResizeFromFile(srcPath, opts)
 
-  assert.NoError(err)
-  
-  destName := fmt.Sprintf("%s%dx%d_%s", outputPrefix, opts.Width, opts.Height, AlgoToString(opts.Algo))
+	assert.NoError(err)
 
-  // Write the resized image back to disk
-  dumpImage(destName, data)
+	destName := fmt.Sprintf("%s%dx%d_%s", outputPrefix, opts.Width, opts.Height, AlgoToString(opts.Algo))
 
-  // Read back the resized image
-  im, _, err := image.DecodeConfig(bytes.NewReader(data))
+	// Write the resized image back to disk
+	dumpImage(destName, data)
 
-  // Make sure the resized image looks good
-  assert.NoError(err)
-  assert.Equal(opts.Width, im.Width)
-  assert.Equal(opts.Height, im.Height)
+	// Read back the resized image
+	im, _, err := image.DecodeConfig(bytes.NewReader(data))
+
+	// Make sure the resized image looks good
+	assert.NoError(err)
+	assert.Equal(opts.Width, im.Width)
+	assert.Equal(opts.Height, im.Height)
 }
 
 //------------------------------------------------------------------------------
 // Make sure that the JSON output indicates an error with expected message
 //------------------------------------------------------------------------------
 func jsonErrorHelper(t *testing.T, jsonString string, expectedErrorMessage string) {
-  
-  assert := assert.New(t)
-  
-  type Message struct {
-    Error_message string
-    Result bool
-  }
-  
-  var m Message
 
-  dec := json.NewDecoder(strings.NewReader(jsonString))
-  
-  decodeError := dec.Decode(&m)
-  
-  assert.NoError(decodeError)
-  assert.Equal(m.Result, false)
-  assert.Equal(m.Error_message, expectedErrorMessage)
+	assert := assert.New(t)
+
+	type Message struct {
+		Error_message string
+		Result        bool
+	}
+
+	var m Message
+
+	dec := json.NewDecoder(strings.NewReader(jsonString))
+
+	decodeError := dec.Decode(&m)
+
+	assert.NoError(decodeError)
+	assert.Equal(m.Result, false)
+	assert.Equal(m.Error_message, expectedErrorMessage)
 }
 
 //------------------------------------------------------------------------------
 // Generic test case
 //------------------------------------------------------------------------------
 func TestJpg(t *testing.T) {
-  cleanup()
-  assert := assert.New(t)
- 
-  srcUrl := "testdata/image.jpg"
-  watermarkUrl := "testdata/watermark.png"
-  watermark2Url := "testdata/watermark2.png"
- 
-  opts := []Options{
-    {Algo: WIDTH,  Quality: 92, Height: 2000,  Width: 150,  SharpenRadius:1.0, SharpenAmount:200},
-    {Algo: WIDTH,  Quality: 20, Height: 2000,  Width: 300,  SharpenRadius:0.5, SharpenAmount:80},
-    {Algo: HEIGHT, Quality: 92, Height: 150,   Width: 2000, SharpenRadius:0.5, SharpenAmount:80},
-    {Algo: HEIGHT, Quality: 92, Height: 300,   Width: 200,  SharpenRadius:0.5, SharpenAmount:80},
-    {Algo: SQUARE, Quality: 92, Height: 100,   Width: 100,  SharpenRadius:0.5, SharpenAmount:80},
-    {Algo: SQUARE, Quality: 92, Height: 300,   Width: 300,  SharpenRadius:0.5, SharpenAmount:80},
-    {Algo: SQUARE, Quality: 92, Height: 400,   Width: 400,  SharpenRadius:0.5, SharpenAmount:80, WatermarkUrl:watermarkUrl, WatermarkAmount: 0.4},
-    {Algo: FILL,   Quality: 92, Height: 600,   Width: 400,  SharpenRadius:0.5, SharpenAmount:80, WatermarkUrl:watermark2Url, WatermarkMin: 0.4, WatermarkMax: 0.6, WatermarkType: ADAPTIVE},
-  }
+	cleanup()
+	assert := assert.New(t)
 
-  for _, opt := range opts {
-    data, _, err := ResizeFromFile(srcUrl, opt)
-  
-    assert.NoError(err)
-  
-    outputName := fmt.Sprintf("image_jpg_to_%dx%d_%s", opt.Width, opt.Height, AlgoToString(opt.Algo))
-  
-    dumpImage(outputName, data)
-    _, _, err = image.DecodeConfig(bytes.NewReader(data))
-    assert.NoError(err)
-  }
+	srcUrl := "testdata/image.jpg"
+	watermarkUrl := "testdata/watermark.png"
+	watermark2Url := "testdata/watermark2.png"
+
+	opts := []Options{
+		{Algo: WIDTH, Quality: 92, Height: 2000, Width: 150, SharpenRadius: 1.0, SharpenAmount: 200},
+		{Algo: WIDTH, Quality: 20, Height: 2000, Width: 300, SharpenRadius: 0.5, SharpenAmount: 80},
+		{Algo: HEIGHT, Quality: 92, Height: 150, Width: 2000, SharpenRadius: 0.5, SharpenAmount: 80},
+		{Algo: HEIGHT, Quality: 92, Height: 300, Width: 200, SharpenRadius: 0.5, SharpenAmount: 80},
+		{Algo: SQUARE, Quality: 92, Height: 100, Width: 100, SharpenRadius: 0.5, SharpenAmount: 80},
+		{Algo: SQUARE, Quality: 92, Height: 300, Width: 300, SharpenRadius: 0.5, SharpenAmount: 80},
+		{Algo: SQUARE, Quality: 92, Height: 400, Width: 400, SharpenRadius: 0.5, SharpenAmount: 80, WatermarkURL: watermarkUrl, WatermarkAmount: 0.4},
+		{Algo: FILL, Quality: 92, Height: 600, Width: 400, SharpenRadius: 0.5, SharpenAmount: 80, WatermarkURL: watermark2Url, WatermarkMin: 0.4, WatermarkMax: 0.6, WatermarkType: ADAPTIVE},
+	}
+
+	for _, opt := range opts {
+		data, _, err := ResizeFromFile(srcUrl, opt)
+
+		assert.NoError(err)
+
+		outputName := fmt.Sprintf("image_jpg_to_%dx%d_%s", opt.Width, opt.Height, AlgoToString(opt.Algo))
+
+		dumpImage(outputName, data)
+		_, _, err = image.DecodeConfig(bytes.NewReader(data))
+		assert.NoError(err)
+	}
 }
 
 //------------------------------------------------------------------------------
 // Test invalid inputs
 //------------------------------------------------------------------------------
 func TestInvalidInput(t *testing.T) {
-  assert := assert.New(t)
-  
-  srcPath := "testdata/does_not_exist.png"
+	assert := assert.New(t)
 
-  opts := Options{
-    Algo:    WIDTH,
-    Width:   50,
-    Height:  50,
-    Quality: 92,
-  }
-  
-  _, jsonString, err := ResizeFromFile(srcPath, opts)
-  
-  assert.Error(err)
-  
-  jsonErrorHelper(t, jsonString, "Failed to extract image")
+	srcPath := "testdata/does_not_exist.png"
+
+	opts := Options{
+		Algo:    WIDTH,
+		Width:   50,
+		Height:  50,
+		Quality: 92,
+	}
+
+	_, jsonString, err := ResizeFromFile(srcPath, opts)
+
+	assert.Error(err)
+
+	jsonErrorHelper(t, jsonString, "Failed to extract image")
 
 }
 
@@ -145,60 +146,61 @@ func TestInvalidInput(t *testing.T) {
 // Basic fill operation
 //------------------------------------------------------------------------------
 func Test100x100(t *testing.T) {
-    
-  srcPath := "testdata/100x100_square.png"
 
-  outputPrefix := "100x100_square_to_"
+	srcPath := "testdata/100x100_square.png"
 
-  opts := Options{
-    Algo:    FILL,
-    Gravity: WEST,
-    Width:   50,
-    Height:  50,
-    Quality: 92,
-  }
-    
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	outputPrefix := "100x100_square_to_"
+
+	opts := Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   50,
+		Height:  50,
+		Quality: 92,
+	}
+
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
+
 //------------------------------------------------------------------------------
 // Here we have a tall source image and we are always cropping a tall portion
 // at the center of the image
 //------------------------------------------------------------------------------
 func Test100x200TallCenter(t *testing.T) {
 
-  srcPath := "testdata/100x200_tall_center.png"
-  outputPrefix := "100x200_tall_center_to_"
+	srcPath := "testdata/100x200_tall_center.png"
+	outputPrefix := "100x200_tall_center_to_"
 
-  // Just a crop, take the center
-  opts := Options{
-    Algo:    FILL,
-    Gravity: CENTER,
-    Width:   50,
-    Height:  200,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the center
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   50,
+		Height:  200,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the center
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH,
-    Width:   25,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   25,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the center
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH,
-    Width:   100,
-    Height:  400,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   100,
+		Height:  400,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -208,38 +210,38 @@ func Test100x200TallCenter(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test100x200TallLeft(t *testing.T) {
 
-  srcPath := "testdata/100x200_tall_left.png"
-  outputPrefix := "100x200_tall_left_to_"
+	srcPath := "testdata/100x200_tall_left.png"
+	outputPrefix := "100x200_tall_left_to_"
 
-  // Just a crop, take the left
-  opts := Options{
-    Algo:    FILL,
-    Gravity: WEST,
-    Width:   50,
-    Height:  200,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the left
+	opts := Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   50,
+		Height:  200,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the left
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_WEST,
-    Width:   25,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   25,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the left
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_WEST,
-    Width:   100,
-    Height:  400,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   100,
+		Height:  400,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -249,38 +251,38 @@ func Test100x200TallLeft(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test100x200TallRight(t *testing.T) {
 
-  srcPath := "testdata/100x200_tall_right.png"
-  outputPrefix := "100x200_tall_right_to_"
+	srcPath := "testdata/100x200_tall_right.png"
+	outputPrefix := "100x200_tall_right_to_"
 
-  // Just a crop, take the right
-  opts := Options{
-    Algo:    FILL,
-    Gravity: EAST,
-    Width:   50,
-    Height:  200,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the right
+	opts := Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   50,
+		Height:  200,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the right
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_EAST,
-    Width:   25,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   25,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the right
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_EAST,
-    Width:   100,
-    Height:  400,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   100,
+		Height:  400,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -290,38 +292,38 @@ func Test100x200TallRight(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test100x200WideBottom(t *testing.T) {
 
-  srcPath := "testdata/100x200_wide_bottom.png"
-  outputPrefix := "100x200_wide_bottom_to_"
+	srcPath := "testdata/100x200_wide_bottom.png"
+	outputPrefix := "100x200_wide_bottom_to_"
 
-  // Just a crop, take the bottom
-  opts := Options{
-    Algo:    FILL,
-    Gravity: SOUTH,
-    Width:   100,
-    Height:  50,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   100,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_EAST,
-    Width:   50,
-    Height:  25,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   50,
+		Height:  25,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_WEST,
-    Width:   200,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   200,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -331,118 +333,120 @@ func Test100x200WideBottom(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test100x200WideCenter(t *testing.T) {
 
-  srcPath := "testdata/100x200_wide_center.png"
-  outputPrefix := "100x200_wide_center_to_"
+	srcPath := "testdata/100x200_wide_center.png"
+	outputPrefix := "100x200_wide_center_to_"
 
-  // Just a crop, take the bottom
-  opts := Options{
-    Algo:    FILL,
-    Gravity: CENTER,
-    Width:   100,
-    Height:  50,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   100,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: EAST,
-    Width:   50,
-    Height:  25,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   50,
+		Height:  25,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: WEST,
-    Width:   200,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   200,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
+
 //------------------------------------------------------------------------------
 // Here we have a tall source image and we are always cropping a wide portion at
 // the top of the image
 //------------------------------------------------------------------------------
 func Test100x200WideTop(t *testing.T) {
 
-  srcPath := "testdata/100x200_wide_top.png"
-  outputPrefix := "100x200_wide_top_to_"
+	srcPath := "testdata/100x200_wide_top.png"
+	outputPrefix := "100x200_wide_top_to_"
 
-  // Just a crop, take the top
-  opts := Options{
-    Algo:    FILL,
-    Gravity: NORTH,
-    Width:   100,
-    Height:  50,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the top
+	opts := Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   100,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the top
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_EAST,
-    Width:   50,
-    Height:  25,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   50,
+		Height:  25,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the top
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_WEST,
-    Width:   200,
-    Height:  100,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   200,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
+
 //------------------------------------------------------------------------------
 // Here we have a wide source image and we are always cropping a tall portion at
 // the center of the image
 //------------------------------------------------------------------------------
 func Test200x100TallCenter(t *testing.T) {
 
-  srcPath := "testdata/200x100_tall_center.png"
-  outputPrefix := "200x100_tall_center_to_"
+	srcPath := "testdata/200x100_tall_center.png"
+	outputPrefix := "200x100_tall_center_to_"
 
-  // Just a crop, take the center
-  opts := Options{
-    Algo:    FILL,
-    Gravity: CENTER,
-    Width:   50,
-    Height:  100,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the center
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   50,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the center
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH,
-    Width:   25,
-    Height:  50,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   25,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the center
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH,
-    Width:   100,
-    Height:  200,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the center
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   100,
+		Height:  200,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -452,38 +456,38 @@ func Test200x100TallCenter(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test200x100TallLeft(t *testing.T) {
 
-  srcPath := "testdata/200x100_tall_left.png"
-  outputPrefix := "200x100_tall_left_to_"
+	srcPath := "testdata/200x100_tall_left.png"
+	outputPrefix := "200x100_tall_left_to_"
 
-  // Just a crop, take the left
-  opts := Options{
-    Algo:    FILL,
-    Gravity: WEST,
-    Width:   50,
-    Height:  100,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the left
+	opts := Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   50,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the left
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_WEST,
-    Width:   25,
-    Height:  50,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   25,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the left
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_WEST,
-    Width:   100,
-    Height:  200,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the left
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   100,
+		Height:  200,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -493,38 +497,38 @@ func Test200x100TallLeft(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test200x100TallRight(t *testing.T) {
 
-  srcPath := "testdata/200x100_tall_right.png"
-  outputPrefix := "200x100_tall_right_to_"
+	srcPath := "testdata/200x100_tall_right.png"
+	outputPrefix := "200x100_tall_right_to_"
 
-  // Just a crop, take the right
-  opts := Options{
-    Algo:    FILL,
-    Gravity: EAST,
-    Width:   50,
-    Height:  100,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the right
+	opts := Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   50,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the right
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_EAST,
-    Width:   25,
-    Height:  50,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   25,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the right
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_EAST,
-    Width:   100,
-    Height:  200,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the right
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   100,
+		Height:  200,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -534,38 +538,38 @@ func Test200x100TallRight(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test200x100WideBottom(t *testing.T) {
 
-  srcPath := "testdata/200x100_wide_bottom.png"
-  outputPrefix := "200x100_wide_bottom_to_"
+	srcPath := "testdata/200x100_wide_bottom.png"
+	outputPrefix := "200x100_wide_bottom_to_"
 
-  // Just a crop, take the bottom
-  opts := Options{
-    Algo:    FILL,
-    Gravity: SOUTH,
-    Width:   200,
-    Height:  50,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: SOUTH,
+		Width:   200,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_EAST,
-    Width:   100,
-    Height:  25,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_EAST,
+		Width:   100,
+		Height:  25,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: SOUTH_WEST,
-    Width:   400,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: SOUTH_WEST,
+		Width:   400,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -575,38 +579,38 @@ func Test200x100WideBottom(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test200x100WideCenter(t *testing.T) {
 
-  srcPath := "testdata/200x100_wide_center.png"
-  outputPrefix := "200x100_wide_center_to_"
+	srcPath := "testdata/200x100_wide_center.png"
+	outputPrefix := "200x100_wide_center_to_"
 
-  // Just a crop, take the bottom
-  opts := Options{
-    Algo:    FILL,
-    Gravity: CENTER,
-    Width:   200,
-    Height:  50,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the bottom
+	opts := Options{
+		Algo:    FILL,
+		Gravity: CENTER,
+		Width:   200,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: EAST,
-    Width:   100,
-    Height:  25,
-  Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: EAST,
+		Width:   100,
+		Height:  25,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the bottom
-  opts = Options{
-    Algo:    FILL,
-    Gravity: WEST,
-    Width:   400,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the bottom
+	opts = Options{
+		Algo:    FILL,
+		Gravity: WEST,
+		Width:   400,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }
 
@@ -616,37 +620,37 @@ func Test200x100WideCenter(t *testing.T) {
 //------------------------------------------------------------------------------
 func Test200x100WideTop(t *testing.T) {
 
-  srcPath := "testdata/200x100_wide_top.png"
-  outputPrefix := "200x100_wide_top_to_"
+	srcPath := "testdata/200x100_wide_top.png"
+	outputPrefix := "200x100_wide_top_to_"
 
-  // Just a crop, take the top
-  opts := Options{
-    Algo:    FILL,
-    Gravity: NORTH,
-    Width:   200,
-    Height:  50,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Just a crop, take the top
+	opts := Options{
+		Algo:    FILL,
+		Gravity: NORTH,
+		Width:   200,
+		Height:  50,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Shrink, take the top
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_EAST,
-    Width:   100,
-    Height:  25,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Shrink, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_EAST,
+		Width:   100,
+		Height:  25,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
-  // Enlarge, take the top
-  opts = Options{
-    Algo:    FILL,
-    Gravity: NORTH_WEST,
-    Width:   400,
-    Height:  100,
-    Quality: 92,
-  }
-  imageTestHelper(t, srcPath, outputPrefix, opts)
+	// Enlarge, take the top
+	opts = Options{
+		Algo:    FILL,
+		Gravity: NORTH_WEST,
+		Width:   400,
+		Height:  100,
+		Quality: 92,
+	}
+	imageTestHelper(t, srcPath, outputPrefix, opts)
 
 }

--- a/options.go
+++ b/options.go
@@ -1,115 +1,146 @@
 package goarion
 
+import (
+	"errors"
+	"strings"
+)
+
 type Gravity int
 
 const (
-    CENTER Gravity = iota
-    NORTH
-    SOUTH
-    WEST
-    EAST
-    NORTH_WEST
-    NORTH_EAST
-    SOUTH_WEST
-    SOUTH_EAST
+	CENTER Gravity = iota
+	NORTH
+	SOUTH
+	WEST
+	EAST
+	NORTH_WEST
+	NORTH_EAST
+	SOUTH_WEST
+	SOUTH_EAST
 )
 
 type Algo int
 
 const (
-    WIDTH Algo = iota
-    HEIGHT
-    SQUARE
-    FILL
+	WIDTH Algo = iota
+	HEIGHT
+	SQUARE
+	FILL
 )
 
 type WatermarkType int
 
 const (
-    STANDARD WatermarkType = iota
-    ADAPTIVE
+	STANDARD WatermarkType = iota
+	ADAPTIVE
 )
 
+func (wt *WatermarkType) UnmarshalText(b []byte) error {
+	str := strings.Trim(string(b), `"`)
+
+	switch str {
+	case "STANDARD":
+		*wt = STANDARD
+	case "ADAPTIVE":
+		*wt = ADAPTIVE
+	default:
+		return errors.New("Unknown WatermarkType: " + string(b))
+	}
+
+	return nil
+}
+
+func (wt WatermarkType) String() string {
+	switch wt {
+	case STANDARD:
+		return "STANDARD"
+	case ADAPTIVE:
+		return "ADAPTIVE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 type Options struct {
-    Width           int
-    Height          int
-    Algo            Algo
-    Gravity         Gravity
-    Quality         int
-    SharpenRadius   float64
-    SharpenAmount   int
-    WatermarkUrl    string;
-    WatermarkType   WatermarkType;
-    WatermarkAmount float64;
-    WatermarkMin    float64;
-    WatermarkMax    float64;
+	Width           int
+	Height          int
+	Algo            Algo
+	Gravity         Gravity
+	Quality         int
+	SharpenRadius   float64
+	SharpenAmount   int
+	WatermarkURL    string
+	WatermarkType   WatermarkType
+	WatermarkAmount float64
+	WatermarkMin    float64
+	WatermarkMax    float64
 }
 
 func AlgoToString(a Algo) string {
-    switch a {
-        case WIDTH:
-            return "width"
-        case HEIGHT:
-            return "height"
-        case SQUARE:
-            return "square"
-        case FILL:
-            return "fill"
-        default:
-            return "invalid"
-    }
+	switch a {
+	case WIDTH:
+		return "width"
+	case HEIGHT:
+		return "height"
+	case SQUARE:
+		return "square"
+	case FILL:
+		return "fill"
+	default:
+		return "invalid"
+	}
 }
 
 func StringToAlgo(s string) Algo {
-    switch s {
-        case "width":
-            return WIDTH
-        case "height":
-            return HEIGHT
-        case "square":
-            return SQUARE
-        default:
-            return FILL
-    }
+	switch s {
+	case "width":
+		return WIDTH
+	case "height":
+		return HEIGHT
+	case "square":
+		return SQUARE
+	default:
+		return FILL
+	}
 }
 
 func GravtiyToString(g Gravity) string {
-    switch g {
-        case NORTH:
-            return "n"
-        case SOUTH:
-            return "s"
-        case WEST:
-            return "w"
-        case EAST:
-            return "e"
-        case NORTH_WEST:
-            return "nw"
-        case NORTH_EAST:
-            return "ne"
-        case SOUTH_WEST:
-            return "sw"
-        case SOUTH_EAST:
-            return "se"
-        default:
-            return "c"
-    }
+	switch g {
+	case NORTH:
+		return "n"
+	case SOUTH:
+		return "s"
+	case WEST:
+		return "w"
+	case EAST:
+		return "e"
+	case NORTH_WEST:
+		return "nw"
+	case NORTH_EAST:
+		return "ne"
+	case SOUTH_WEST:
+		return "sw"
+	case SOUTH_EAST:
+		return "se"
+	default:
+		return "c"
+	}
 }
 
 func WatermarkTypeToString(w WatermarkType) string {
-    switch w {
-        case ADAPTIVE:
-            return "adaptive"
-        default:
-            return "standard"
-    }
+	switch w {
+	case ADAPTIVE:
+		return "adaptive"
+	default:
+		return "standard"
+	}
 }
 
 func StringToWatermarkType(s string) WatermarkType {
-    switch s {
-        case "adaptive":
-            return ADAPTIVE
-        default:
-            return STANDARD
-    }
+	switch s {
+	case "adaptive":
+		return ADAPTIVE
+	default:
+		return STANDARD
+	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,47 @@
+package goarion
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+var watermarkTypeDeserializationTests = []struct {
+	text        []byte
+	expected    WatermarkType
+	expectError bool
+}{
+	{[]byte("STANDARD"), STANDARD, false},
+	{[]byte("ADAPTIVE"), ADAPTIVE, false},
+	{[]byte("BANANA"), -1, true},
+}
+
+func TestWatermarkTypeDeserialization(t *testing.T) {
+	for _, test := range watermarkTypeDeserializationTests {
+		// Need weird indirection to be able to test
+		// a pointer to a WatermarkType
+		var wmt *WatermarkType
+		std := STANDARD
+		wmt = &std
+		err := wmt.UnmarshalText(test.text)
+		if err != nil {
+			if !test.expectError {
+				t.Error(err)
+			}
+		} else {
+			assert.Equal(t, test.expected, *wmt)
+		}
+	}
+}
+
+var watermarkTypeStringTests = []struct {
+	wmt      WatermarkType
+	expected string
+}{
+	{STANDARD, "STANDARD"},
+	{ADAPTIVE, "ADAPTIVE"},
+	{-1, "UNKNOWN"},
+}
+
+func TestWatermarkTypeString(t *testing.T) {
+	for _, test := range watermarkTypeStringTests {
+		assert.Equal(t, test.expected, test.wmt.String())
+	}
+}


### PR DESCRIPTION
I think you have have not been running go fmt? Not sure why else it's saying it's all new code (spaces -> tabs)

Anyways:

Add:
WatermarkType String() and UnmarshalText methods

Change:
Make go linter happy

Remove:
Some commented out code